### PR TITLE
feat: add MongoDB Atlas connection setup

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,35 @@
+import express from "express";
+import connectDB from "./mongoose/connection.js"
+import dotenv from "dotenv";
+import cookieParser from "cookie-parser";
+import cors from "cors" ;
+
+
+dotenv.config({
+    path: './.env'
+})
+
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+
+app.use(cors({
+  origin: "*",
+  credentials: false
+}));
+
+
+app.use(express.json());
+app.use(cookieParser());
+
+
+connectDB()
+.then(()=>{
+    app.listen(PORT, () => {
+        console.log(`Server running on http://localhost:${PORT}`);
+      });
+}).catch((err)=>{
+    console.log("MONGODB connection failed!!! ",err)
+})
+

--- a/backend/constants.js
+++ b/backend/constants.js
@@ -1,0 +1,1 @@
+export const DB_NAME='proximity_alert'

--- a/backend/mongoose/connection.js
+++ b/backend/mongoose/connection.js
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+import { DB_NAME } from "../constants.js";
+
+const connectDB = async () => {
+  try {
+    const connectionInstance = await mongoose.connect(
+      `${process.env.MONGODB_URI}/${DB_NAME}`,
+      {
+        serverSelectionTimeoutMS: 5000
+      }
+    );
+
+    console.log("✅ MongoDB connected");
+  } catch (error) {
+    console.log("❌ MongoDB connection error:", error);
+    process.exit(1);
+  }
+};
+
+export default connectDB;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^17.1.0",
         "express": "^5.1.0",
@@ -297,6 +298,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,15 +3,17 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "nodemon app.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.1.0",
     "express": "^5.1.0",


### PR DESCRIPTION
✅ Summary
This PR sets up the initial database connection for the backend using MongoDB Atlas and integrates it with the Express server.

📦 Changes Introduced
Connected MongoDB using Mongoose and Atlas URI from .env
Added environment variables (MONGODB_URI, DB_NAME)
Set up connectDB() utility with error handling and logs
Verified connection with npm run dev

✅ Tested With
Local run via npm run dev
Atlas cluster connection successful
Server logs confirm DB connection

